### PR TITLE
feat: add beacon path tracking

### DIFF
--- a/coke-people-tracking-1-2/client/src/hooks/useBeaconPath.tsx
+++ b/coke-people-tracking-1-2/client/src/hooks/useBeaconPath.tsx
@@ -1,0 +1,34 @@
+import { useState, useCallback } from "react";
+import useAxiosPrivate from "@/hooks/auth/useAxiosPrivate";
+import { handleApiError } from "@/helpers/handleApiError";
+import { BeaconPath } from "@/interfaces/device";
+import { Battery } from "@/interfaces/map";
+
+const useBeaconPath = () => {
+  const axiosPrivate = useAxiosPrivate();
+  const [path, setPath] = useState<BeaconPath[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchPath = useCallback(
+    async (bnid: number, date: string, battery: Battery) => {
+      try {
+        setLoading(true);
+        const res = await axiosPrivate.get<BeaconPath[]>("/beacon/path", {
+          params: { bnid, date, battery },
+        });
+        setPath(res.data);
+        return res.data;
+      } catch (error) {
+        handleApiError(error);
+        return [];
+      } finally {
+        setLoading(false);
+      }
+    },
+    [axiosPrivate]
+  );
+
+  return { path, loading, fetchPath };
+};
+
+export default useBeaconPath;

--- a/coke-people-tracking-1-2/client/src/interfaces/device.ts
+++ b/coke-people-tracking-1-2/client/src/interfaces/device.ts
@@ -91,3 +91,12 @@ export interface AssignmentHistory {
   employee: string;
   assignedAt: string;
 }
+
+export interface BeaconPath {
+  bnid: number;
+  latestCpid: number;
+  latestGwid: number;
+  latestBoundingBox: number[];
+  location: Battery;
+  createdAt: string;
+}

--- a/coke-people-tracking-1-2/client/src/routes/dashboard/components/BeaconPathTracker.tsx
+++ b/coke-people-tracking-1-2/client/src/routes/dashboard/components/BeaconPathTracker.tsx
@@ -1,0 +1,77 @@
+import { useState, useContext } from "react";
+import { Button, Modal, DatePicker, Select } from "antd";
+import dayjs, { Dayjs } from "dayjs";
+import DeviceContext from "@/context/DeviceContext";
+import MapContext from "@/context/MapContext";
+import useBeaconPath from "@/hooks/useBeaconPath";
+import { Battery } from "@/interfaces/map";
+import { BeaconPath } from "@/interfaces/device";
+
+interface BeaconPathTrackerProps {
+  onPathFetched: (path: BeaconPath[]) => void;
+}
+
+const BeaconPathTracker: React.FC<BeaconPathTrackerProps> = ({ onPathFetched }) => {
+  const { beacons } = useContext(DeviceContext);
+  const { setLocation } = useContext(MapContext);
+  const { fetchPath, loading } = useBeaconPath();
+
+  const [open, setOpen] = useState(false);
+  const [bnid, setBnid] = useState<number | null>(null);
+  const [battery, setBattery] = useState<Battery>(Battery.one);
+  const [date, setDate] = useState<Dayjs | null>(dayjs());
+
+  const handleOk = async () => {
+    if (!bnid || !date) return;
+    const result = await fetchPath(bnid, date.format("YYYY-MM-DD"), battery);
+    onPathFetched(result);
+    setLocation(battery);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Button
+        className="absolute top-2 right-48 z-50"
+        type="primary"
+        onClick={() => setOpen(true)}
+      >
+        Track Path
+      </Button>
+      <Modal
+        title="Track Beacon Path"
+        open={open}
+        onOk={handleOk}
+        onCancel={() => setOpen(false)}
+        okText="Fetch"
+        confirmLoading={loading}
+      >
+        <div className="flex flex-col gap-4">
+          <DatePicker
+            value={date}
+            onChange={(d) => setDate(d)}
+            className="w-full"
+          />
+          <Select
+            value={battery}
+            onChange={(value) => setBattery(value)}
+            options={[
+              { value: Battery.one, label: "Battery 1" },
+              { value: Battery.two, label: "Battery 2" },
+            ]}
+            className="w-full"
+          />
+          <Select
+            value={bnid ?? undefined}
+            onChange={(value) => setBnid(value)}
+            placeholder="Select Beacon"
+            options={beacons.map((b) => ({ value: b.bnid, label: `0${b.bnid}` }))}
+            className="w-full"
+          />
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export default BeaconPathTracker;

--- a/coke-people-tracking-1-2/client/src/routes/dashboard/index.tsx
+++ b/coke-people-tracking-1-2/client/src/routes/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import clsx from "clsx";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
@@ -15,6 +15,8 @@ import { usePolling } from "@/hooks/usePolling";
 import ActiveUserList from "@/layout/components/ActiveUserList";
 import MapContext from "@/context/MapContext";
 import SelectCellar from "./components/SelectCellar";
+import BeaconPathTracker from "./components/BeaconPathTracker";
+import { BeaconPath } from "@/interfaces/device";
 
 const Dashboard: React.FC = () => {
   const { ref, transformWrapperRef, enterFullscreen } = useFullscreen();
@@ -28,9 +30,8 @@ const Dashboard: React.FC = () => {
     showBoundingBox,
     toggleShowBoundingBox,
   } = useAddBoundingBox();
-  const { beacons, fetchConnectPoints, fetchGateways } = useContext(
-    DeviceContext
-  );
+  const { beacons, fetchConnectPoints, fetchGateways } = useContext(DeviceContext);
+  const [path, setPath] = useState<BeaconPath[]>([]);
 
   usePolling(fetchConnectPoints, 3000);
   usePolling(fetchGateways, 3000);
@@ -69,6 +70,7 @@ const Dashboard: React.FC = () => {
               {isFullScreen && <AlarmNotification beacons={beacons} />}
               {isFullScreen && <ActiveUserList beacons={beacons} />}
               <SelectCellar />
+              <BeaconPathTracker onPathFetched={setPath} />
 
               <TransformComponent
                 wrapperStyle={{
@@ -81,6 +83,7 @@ const Dashboard: React.FC = () => {
                 <CellarAreaMap
                   addBoundingBox={addBoundingBox}
                   showBoundingBox={showBoundingBox}
+                  path={path}
                 />
               </TransformComponent>
             </div>

--- a/coke-people-tracking-1-2/server/src/resources/beacon/beacon.controller.ts
+++ b/coke-people-tracking-1-2/server/src/resources/beacon/beacon.controller.ts
@@ -8,10 +8,12 @@ import {
   ClearEmployeeSchema,
   UpdateBeaconSchema,
   GetBeaconsSchema,
+  GetBeaconPathSchema,
 } from "./beacon.validation";
 import { errorHandler } from "@/utils/error-handler";
 import BeaconService from "./beacon.service";
 import { BeaconLocation, BeaconStatus } from "./beacon.interface";
+import { Battery } from "@/utils/interfaces/common";
 
 class BeaconController implements Controller {
   public path = "/beacon";
@@ -32,6 +34,11 @@ class BeaconController implements Controller {
       `${this.path}/`,
       validateSchema({ query: GetBeaconsSchema }),
       errorHandler(this.getBeacons)
+    );
+    this.router.get(
+      `${this.path}/path`,
+      validateSchema({ query: GetBeaconPathSchema }),
+      errorHandler(this.getBeaconPath)
     );
     this.router.delete(
       `${this.path}/delete/:bnid`,
@@ -159,6 +166,21 @@ class BeaconController implements Controller {
   ): Promise<Response | void> => {
     const history = await this.BeaconService.getAssignmentHistory();
     res.json(history);
+  };
+
+  private getBeaconPath = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { bnid, date, battery } = req.query;
+    const location = (battery as Battery) as unknown as BeaconLocation;
+    const path = await this.BeaconService.getBeaconPath(
+      Number(bnid),
+      date as string,
+      location
+    );
+    res.json(path);
   };
 }
 

--- a/coke-people-tracking-1-2/server/src/resources/beacon/beacon.interface.ts
+++ b/coke-people-tracking-1-2/server/src/resources/beacon/beacon.interface.ts
@@ -28,3 +28,12 @@ export interface IAssignmentHistory {
   employee: string;
   assignedAt: Date;
 }
+
+export interface IBeaconTrack {
+  bnid: number;
+  latestCpid: number;
+  latestGwid: number;
+  latestBoundingBox: number[];
+  location: BeaconLocation;
+  createdAt: Date;
+}

--- a/coke-people-tracking-1-2/server/src/resources/beacon/beacon.validation.ts
+++ b/coke-people-tracking-1-2/server/src/resources/beacon/beacon.validation.ts
@@ -58,3 +58,11 @@ export const UpdateBeaconSchema = z.object({
     })
     .optional(),
 });
+
+export const GetBeaconPathSchema = z.object({
+  bnid: z.coerce.number().min(1).max(50),
+  date: z.string().refine((val) => !isNaN(Date.parse(val)), {
+    message: "Invalid date format",
+  }),
+  battery: z.nativeEnum(Battery),
+});

--- a/coke-people-tracking-1-2/server/src/resources/beacon/beaconTrack.model.ts
+++ b/coke-people-tracking-1-2/server/src/resources/beacon/beaconTrack.model.ts
@@ -1,0 +1,24 @@
+import { Schema, model } from "mongoose";
+import { IBeaconTrack, BeaconLocation } from "./beacon.interface";
+
+const BeaconTrackSchema = new Schema<IBeaconTrack>(
+  {
+    bnid: { type: Number, required: true },
+    latestCpid: { type: Number, required: true },
+    latestGwid: { type: Number, required: true },
+    latestBoundingBox: { type: [Number], required: true },
+    location: {
+      type: String,
+      enum: Object.values(BeaconLocation),
+      required: true,
+    },
+    createdAt: {
+      type: Date,
+      default: () => new Date(),
+      required: true,
+    },
+  },
+  { timestamps: true, versionKey: false }
+);
+
+export default model<IBeaconTrack>("BeaconTrack", BeaconTrackSchema);


### PR DESCRIPTION
## Summary
- add hook and modal to fetch beacon paths and plot them on the map
- draw beacon path polyline based on recorded bounding boxes

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm test --prefix client` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad71113198832aa0819841a6493644