### PR TITLE
Add clear path control and reset on battery change

### DIFF
--- a/coke-people-tracking-1-2/client/src/routes/dashboard/components/BeaconPathTracker.tsx
+++ b/coke-people-tracking-1-2/client/src/routes/dashboard/components/BeaconPathTracker.tsx
@@ -9,9 +9,15 @@ import { BeaconPath } from "@/interfaces/device";
 
 interface BeaconPathTrackerProps {
   onPathFetched: (path: BeaconPath[]) => void;
+  onClearPath: () => void;
+  tracking: boolean;
 }
 
-const BeaconPathTracker: React.FC<BeaconPathTrackerProps> = ({ onPathFetched }) => {
+const BeaconPathTracker: React.FC<BeaconPathTrackerProps> = ({
+  onPathFetched,
+  onClearPath,
+  tracking,
+}) => {
   const { beacons } = useContext(DeviceContext);
   const { setLocation } = useContext(MapContext);
   const { fetchPath, loading } = useBeaconPath();
@@ -28,6 +34,18 @@ const BeaconPathTracker: React.FC<BeaconPathTrackerProps> = ({ onPathFetched }) 
     setLocation(battery);
     setOpen(false);
   };
+
+  if (tracking)
+    return (
+      <Button
+        className="absolute top-2 right-48 z-50"
+        type="primary"
+        danger
+        onClick={onClearPath}
+      >
+        Clear Path
+      </Button>
+    );
 
   return (
     <>

--- a/coke-people-tracking-1-2/client/src/routes/dashboard/index.tsx
+++ b/coke-people-tracking-1-2/client/src/routes/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect } from "react";
 import clsx from "clsx";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
@@ -20,7 +20,7 @@ import { BeaconPath } from "@/interfaces/device";
 
 const Dashboard: React.FC = () => {
   const { ref, transformWrapperRef, enterFullscreen } = useFullscreen();
-  const { scale, setScale, isFullScreen } = useContext(MapContext);
+  const { scale, setScale, isFullScreen, location } = useContext(MapContext);
   const { addGateway, handleAddGateway } = useAddGateway();
   const { addConnectPoint, handleAddConnectPoint } = useAddConnectPoint();
   const {
@@ -35,6 +35,10 @@ const Dashboard: React.FC = () => {
 
   usePolling(fetchConnectPoints, 3000);
   usePolling(fetchGateways, 3000);
+
+  useEffect(() => {
+    setPath([]);
+  }, [location]);
 
   const handleMapClick = (event: React.MouseEvent) => {
     if (addGateway.active) handleAddGateway(event);
@@ -70,7 +74,11 @@ const Dashboard: React.FC = () => {
               {isFullScreen && <AlarmNotification beacons={beacons} />}
               {isFullScreen && <ActiveUserList beacons={beacons} />}
               <SelectCellar />
-              <BeaconPathTracker onPathFetched={setPath} />
+              <BeaconPathTracker
+                onPathFetched={setPath}
+                onClearPath={() => setPath([])}
+                tracking={path.length > 0}
+              />
 
               <TransformComponent
                 wrapperStyle={{


### PR DESCRIPTION
## Summary
- toggle clear path button when a beacon path is active
- reset beacon path display when the battery location changes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 27 problems (15 errors, 12 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68ad91ec96e8832aa1fade2c0f2c737a